### PR TITLE
updated bower dependency for moment-timezone js library

### DIFF
--- a/app/pages/channel/channelServices.js
+++ b/app/pages/channel/channelServices.js
@@ -34,6 +34,7 @@ angular.module("mnd-web.pages")
 		);
 	};
 	var canDeleteEntry = function (user, channel, entry) {
+		if(!user) return false;		
 		return (
 			isOwner(user, channel) ||
 			isCurator(user, channel) ||

--- a/deps.json
+++ b/deps.json
@@ -23,7 +23,7 @@
         "bower_components/mnd-dashboard/dist/dashboard-tpls.js",
         "bower_components/mnd-sprinkle/dist/sprinkle-tpls.js",
         "bower_components/moment/moment.js",
-        "bower_components/moment-timezone/builds/moment-timezone-with-data-2010-2020.js",
+        "bower_components/moment-timezone/builds/moment-timezone-with-data-2012-2022.js",
         "bower_components/ng-file-upload/angular-file-upload.js",
         "bower_components/ng-file-upload/angular-file-upload-shim.js",
         "bower_components/q/q.js"


### PR DESCRIPTION
On angular pipe "epochToLocal" (app/pages/home/home.js) moment.unix().tz() is throwing an exception. 
This is due to a reference to "moment-timezone-with-data-2010-2020.js" which has been replaced with moment-timezone-with-data-2012-2022.js"