### PR TITLE
feat: add site-metadata + improve SEO

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,17 +1,25 @@
 module.exports = {
     siteMetadata: {
-        title: ":mondora: building software, creating benefit",
-        description: "Our aim is to create benefit for all stakeholders by designing and building software solutions that maximise positive impact. We support humans and nature with projects that benefit the community and land.",
+        siteUrl: "https://mondora.com",
+        title: ":mondora - building software, creating benefit",
+        description:
+            "Our aim is to create benefit for all stakeholders by designing and building software solutions that maximise positive impact. We support humans and nature with projects that benefit the community and land.",
         author: "mondora-team"
     },
     plugins: [
         "gatsby-plugin-react-helmet",
+        {
+            resolve: `gatsby-source-instagram`,
+            options: {
+                username: `mondoracom`
+            }
+        },
         "gatsby-plugin-styled-components",
         {
             resolve: `gatsby-source-rss-feed`,
             options: {
                 url: `https://bcalmbcorp.com/feed/`,
-                name: `BcalmBcorp`,
+                name: `BcalmBcorp`
             }
         },
         {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,31 +1,11 @@
-// const env = require("@mondora/env").default;
-
-// const nodeEnv = env("NODE_ENV", { default: "development" });
-
-// require("dotenv").config({
-//     path: `${__dirname}/.env.${nodeEnv}`
-// });
-
-// const contentfulSpaceId = env("CONTENTFUL_SPACE_ID", { required: true });
-// const contentfulAccessToken = env("CONTENTFUL_ACCESS_TOKEN", {
-//     required: true
-// });
-
 module.exports = {
     siteMetadata: {
-        title: ":mondora's website",
-        // TODO: write a decent description.
-        description: ":mondora",
+        title: ":mondora: building software, creating benefit",
+        description: "Our aim is to create benefit for all stakeholders by designing and building software solutions that maximise positive impact. We support humans and nature with projects that benefit the community and land.",
         author: "mondora-team"
     },
     plugins: [
         "gatsby-plugin-react-helmet",
-        {
-            resolve: `gatsby-source-instagram`,
-            options: {
-                username: `mondoracom`
-            }
-        },
         "gatsby-plugin-styled-components",
         {
             resolve: `gatsby-source-rss-feed`,
@@ -41,17 +21,10 @@ module.exports = {
                 name: ":mondora",
                 short_name: ":m",
                 start_url: "/",
-                background_color: "#663399",
-                theme_color: "#663399",
+                background_color: "#f2f2f2",
+                theme_color: "#ffda03",
                 display: "minimal-ui"
             }
         }
-        // {
-        //     resolve: `gatsby-source-contentful`,
-        //     options: {
-        //         spaceId: process.env.CONTENTFUL_SPACE_ID,
-        //         accessToken: process.env.CONTENTFUL_ACCESS_TOKEN
-        //     }
-        // }
     ]
 };

--- a/src/components/layout/index.jsx
+++ b/src/components/layout/index.jsx
@@ -3,11 +3,9 @@ import React from "react";
 import styled, { ThemeProvider } from "styled-components";
 import { theme } from "../../styles/theme";
 
+import SiteMetadata from "../site-metadata";
 import Menu from "./menu";
 import Footer from "./footer";
-
-import logoWhite from "./assets/mondora-logo-white.svg";
-import bannerPath from "./assets/Banner-970x90-Cool-Down.png";
 
 const Container = styled.div`
     display: grid;
@@ -29,71 +27,20 @@ const FooterContainer = styled.div`
     grid-area: 3 / 1 / 4 / 2;
 `;
 
-//TODO temporary component
-const BlurredWrapper = styled.div`
-    filter: blur(2px);
-`;
-
-const TemporaryTitle = styled.h1`
-    color: var(--white);
-    font-size: 56px;
-    padding: 0 16px;
-    text-align: center;
-`;
-
-const Overlay = styled.div`
-    position: fixed;
-    width: 100%;
-    height: 100%;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: rgba(0, 0, 0, 0.8);
-    z-index: 2;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-direction: column;
-`;
-
-const WhiteLogo = styled.img`
-    max-width: 300px;
-`;
-
-const Banner = styled.img`
-    margin-top: 16px;
-    width: 100%;
-`;
-
-const VideoContainer = styled.div`
-    width: 50%;
-    height: 50%;
-
-    @media (max-width: 1024px) {
-        height: 30%;
-    }
-
-    @media (max-width: 700px) {
-        width: 80%;
-    }
-`;
-//---------------------
-
 const Layout = ({ children }) => (
     <ThemeProvider theme={theme}>
+        <SiteMetadata />
         <div>
-            
-                <Container>
-                    <MenuContainer>
-                        <Menu />
-                    </MenuContainer>
-                    <ContentContainer>{children}</ContentContainer>
-                    <FooterContainer>
-                        <Footer />
-                    </FooterContainer>
-                </Container>
-            </div>
+            <Container>
+                <MenuContainer>
+                    <Menu />
+                </MenuContainer>
+                <ContentContainer>{children}</ContentContainer>
+                <FooterContainer>
+                    <Footer />
+                </FooterContainer>
+            </Container>
+        </div>
     </ThemeProvider>
 );
 

--- a/src/components/site-metadata/index.jsx
+++ b/src/components/site-metadata/index.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Helmet } from "react-helmet";
+import { graphql, useStaticQuery } from "gatsby";
+
+const SiteMetadata = ({ post }) => {
+    const data = useStaticQuery(graphql`
+        {
+            site {
+                siteMetadata {
+                    title
+                    description
+                    siteUrl
+                }
+            }
+        }
+    `);
+
+    const defaults = data.site.siteMetadata;
+
+    if (defaults.siteUrl === "" && typeof window !== "undefined") {
+        defaults.siteUrl = window.location.origin;
+    }
+
+    if (defaults.siteUrl === "") {
+        console.error("Please set a baseUrl in your site metadata!");
+        return null;
+    }
+
+    const title = defaults.title;
+    const description = defaults.description;
+    const url = new URL(defaults.siteUrl);
+
+    return (
+        <Helmet>
+            <title>{title}</title>
+            <link rel="canonical" href={url} />
+            <meta name="description" content={description} />
+        </Helmet>
+    );
+};
+
+export default SiteMetadata;

--- a/src/components/site-metadata/index.jsx
+++ b/src/components/site-metadata/index.jsx
@@ -16,16 +16,6 @@ const SiteMetadata = ({ post }) => {
     `);
 
     const defaults = data.site.siteMetadata;
-
-    if (defaults.siteUrl === "" && typeof window !== "undefined") {
-        defaults.siteUrl = window.location.origin;
-    }
-
-    if (defaults.siteUrl === "") {
-        console.error("Please set a baseUrl in your site metadata!");
-        return null;
-    }
-
     const title = defaults.title;
     const description = defaults.description;
     const url = new URL(defaults.siteUrl);


### PR DESCRIPTION
Con questa PR:

- Aggiunto component `site-metadata` per gestire in modo centralizzato il SEO
- Modificato il default SEO title - aggiunto la default SEO description
- Modificato i colori della PWA - giallo + grigio
- Rimosso codice commentato
- Rimosso style legato al climate strike

