### PR TITLE
feat: add basic SEO component

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,7 +1,9 @@
 module.exports = {
     siteMetadata: {
-        title: ":mondora's website",
-        description: ":mondora",
+        siteUrl: "https://mondora.com",
+        title: ":mondora - Building software, creating benefit",
+        description:
+            "Software and advisory company specialized in custom cloud solutions. Our aim is to create benefit for all stakeholders by designing and building software solutions that maximise positive impact.",
         author: "mondora-team"
     },
     plugins: [
@@ -24,8 +26,8 @@ module.exports = {
                 name: ":mondora",
                 short_name: ":m",
                 start_url: "/",
-                background_color: "#663399",
-                theme_color: "#663399",
+                background_color: "#f2f2f2",
+                theme_color: "#ffda01",
                 display: "minimal-ui"
             }
         },

--- a/src/components/page-metadata/index.jsx
+++ b/src/components/page-metadata/index.jsx
@@ -1,0 +1,37 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Helmet } from "react-helmet";
+import { graphql, useStaticQuery } from "gatsby";
+
+const PageMetadata = ({ title, description }) => {
+    const data = useStaticQuery(graphql`
+        {
+            site {
+                siteMetadata {
+                    title
+                    description
+                }
+            }
+        }
+    `);
+
+    const defaults = data.site.siteMetadata;
+    const seo = {
+        title: title || defaults.title,
+        description: description || defaults.description
+    };
+
+    return (
+        <Helmet>
+            <title>{seo.title}</title>
+            <meta name="description" content={seo.description} />
+        </Helmet>
+    );
+};
+
+PageMetadata.propTypes = {
+    title: PropTypes.string,
+    description: PropTypes.string
+};
+
+export default PageMetadata;

--- a/src/pages/about/index.jsx
+++ b/src/pages/about/index.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import Layout from "../../components/layout";
+import PageMetadata from "../../components/page-metadata";
 
 import Header from "../../components/pages/about-us/header";
 import WhoWeAre from "../../components/pages/about-us/who-we-are";
@@ -9,6 +10,10 @@ import WhereAreWeDreamingOfGoingTogether from "../../components/pages/about-us/w
 
 const About = () => (
     <Layout>
+        <PageMetadata
+            title="Software and advisory company specilized in custom cloud solutions - mondora"
+            description="mondora: a passionate and dedicated team of over 60 full-stack software developers, UX designers, system administrators… and a few farmers!"
+        />
         <Header />
         <WhoWeAre />
         <WhereDoWeComeFrom />

--- a/src/pages/bcorp/index.jsx
+++ b/src/pages/bcorp/index.jsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import Layout from "../../components/layout";
 import MaxWidthContainer from "../../components/max-width-container";
+import PageMetadata from "../../components/page-metadata";
 import Title from "../../components/title";
 import Subtitle from "../../components/subtitle";
 import JumboTitle from "../../components/jumbo-title";
@@ -142,6 +143,10 @@ const reports = [
 
 const BCorp = () => (
     <Layout>
+        <PageMetadata
+            title="Let’s change the world together - Certified B Corp company - :mondora"
+            description="In mondora we all work towards a shared purpose: making the world a better place. "
+        />
         <BackgroundStripe>
             <MaxWidthContainer>
                 <Section header={true}>

--- a/src/pages/contacts/index.jsx
+++ b/src/pages/contacts/index.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import Divider from "../../components/divider";
+import PageMetadata from "../../components/page-metadata";
 
 import KeepInTouch from "../../components/pages/contacts/keep-in-touch";
 import WhereToFindUs from "../../components/pages/contacts/where-to-find-us";
@@ -13,6 +14,10 @@ import BackgroundStripe from "../../components/background-stripe";
 
 const Contacts = () => (
     <Layout>
+        <PageMetadata
+            title="Contacts - mondora - Software and advisory company specilized in custom cloud solutions"
+            description="Whether you are interested in working with us on a custom software solution for your business, or are just curious about the :m world, we would love to get in touch!"
+        />
         <MaxWidthContainer>
             <BackgroundStripe>
                 <Section header={true}>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 
 import Layout from "../components/layout";
+import PageMetadata from "../components/page-metadata";
+
 import Header from "../components/pages/home/header";
 import WhatWeCanDo from "../components/pages/home/what-we-can-do";
 
@@ -21,6 +23,7 @@ const rebassTheme = {
 const Homepage = () => (
     <Layout>
         <ThemeProvider theme={rebassTheme}>
+            <PageMetadata />
             <Header />
             <WhatWeCanDo />
             <Blog />

--- a/src/pages/work-with-us/index.jsx
+++ b/src/pages/work-with-us/index.jsx
@@ -6,6 +6,7 @@ import styled from "styled-components";
 
 import { Flex, Box } from "reflexbox";
 
+import PageMetadata from "../../components/page-metadata";
 import SquareButton from "../../components/square-button";
 import Section from "../../components/section";
 import Divider from "../../components/divider";
@@ -135,6 +136,10 @@ const WorkWithUs = () => {
 
     return (
         <Layout>
+            <PageMetadata
+                title="Join the :m team! - Work with us - mondora"
+                description="We are a diverse team of passionate people putting our unique skills to work towards a shared purpose: making the world a better place throug software solutions."
+            />
             <MaxWidthContainer>
                 <BackgroundStripe>
                     <Section header={true}>


### PR DESCRIPTION
Con questa PR:

- Aggiunto component `page-metadata` per gestire in modo centralizzato la SEO
- Modificato il default SEO title - aggiunto la default SEO description
- Modificato i colori della PWA - giallo + grigio
- Aggiunto title e description a tutte le pagine

Si tratta della base, ci sono diversi meta tag da implementare, al momento sono rimasto sul semplice