### PR TITLE
feat: improve a11y 

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,7 +10,8 @@ module.exports = {
             "Software and advisory company specialized in custom cloud solutions. Our aim is to create benefit for all stakeholders by designing and building software solutions that maximise positive impact.",
         author: "mondora-team",
         robots:
-            "index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1"
+            "index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1",
+        locale: "en"
     },
     plugins: [
         "gatsby-plugin-transition-link",

--- a/src/components/layout/footer/index.jsx
+++ b/src/components/layout/footer/index.jsx
@@ -12,7 +12,7 @@ import SocialLink from "../../social-link";
 import Hidden from "../../hidden";
 import Subtitle from "../../subtitle";
 
-const FooterContainer = styled.div`
+const FooterContainer = styled.footer`
     display: flex;
     border-top: 1px solid var(--border-dark-gray);
     background: var(--background-dark-gray);
@@ -87,7 +87,7 @@ const Footer = () => {
     ];
 
     return (
-        <FooterContainer>
+        <FooterContainer role="contentinfo">
             <MaxWidthContainer
                 width="100%"
                 my={4}
@@ -141,11 +141,13 @@ const Footer = () => {
                             pl={3}
                         >
                             <Subtitle light={true}>{column.title}</Subtitle>
-                            {column.links.map((link, i) => (
-                                <ExternalLink key={i} href={link.link}>
-                                    {link.text}
-                                </ExternalLink>
-                            ))}
+                            <nav role="navigation" aria-label={column.title}>
+                                {column.links.map((link, i) => (
+                                    <ExternalLink key={i} href={link.link}>
+                                        {link.text}
+                                    </ExternalLink>
+                                ))}
+                            </nav>
                         </Flex>
                     ))}
                 </Flex>

--- a/src/components/layout/index.jsx
+++ b/src/components/layout/index.jsx
@@ -11,7 +11,7 @@ import CookiesAlert from "./cookies-alert";
 const Layout = ({ children }) => (
     <ThemeProvider theme={theme}>
         <Menu />
-        {children}
+        <main>{children}</main>
         <Footer />
         <CookiesAlert />
     </ThemeProvider>

--- a/src/components/layout/menu/desktop/index.jsx
+++ b/src/components/layout/menu/desktop/index.jsx
@@ -57,41 +57,42 @@ const DesktopMenu = ({ internal, external, blog }) => {
                     alt={contentfulMenu.desktopLogo.title}
                 />
             </AniLink>
+            <nav role="navigation" aria-label="Main">
+                <Flex justifyContent="space-between" alignItems="center">
+                    {internal.map((link, i) => (
+                        <SuperLink
+                            key={i}
+                            to={link.link}
+                            paintDrip
+                            direction="none"
+                            color="white"
+                            activeClassName="active"
+                        >
+                            {link.text}
+                        </SuperLink>
+                    ))}
 
-            <Flex justifyContent="space-between" alignItems="center">
-                {internal.map((link, i) => (
-                    <SuperLink
-                        key={i}
-                        to={link.link}
-                        paintDrip
-                        direction="none"
-                        color="white"
-                        activeClassName="active"
-                    >
-                        {link.text}
-                    </SuperLink>
-                ))}
+                    {external.map((link, i) => (
+                        <SuperLink
+                            key={i}
+                            as="a"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            href={link.link}
+                        >
+                            {link.text}
+                        </SuperLink>
+                    ))}
 
-                {external.map((link, i) => (
-                    <SuperLink
-                        key={i}
-                        as="a"
+                    <BlogButton
                         target="_blank"
                         rel="noopener noreferrer"
-                        href={link.link}
+                        href={blog.link}
                     >
-                        {link.text}
-                    </SuperLink>
-                ))}
-
-                <BlogButton
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href={blog.link}
-                >
-                    {blog.text}
-                </BlogButton>
-            </Flex>
+                        {blog.text}
+                    </BlogButton>
+                </Flex>
+            </nav>
         </Flex>
     );
 };

--- a/src/components/layout/menu/desktop/index.jsx
+++ b/src/components/layout/menu/desktop/index.jsx
@@ -40,6 +40,7 @@ const DesktopMenu = ({ internal, external, blog }) => {
         query {
             contentfulMenu {
                 desktopLogo {
+                    title
                     fixed(width: 156) {
                         ...GatsbyContentfulFixed
                     }
@@ -51,7 +52,10 @@ const DesktopMenu = ({ internal, external, blog }) => {
     return (
         <Flex my={32} justifyContent="space-between" alignItems="center">
             <AniLink to="/" paintDrip direction="none" color="white">
-                <Image fixed={contentfulMenu.desktopLogo.fixed} />
+                <Image
+                    fixed={contentfulMenu.desktopLogo.fixed}
+                    alt={contentfulMenu.desktopLogo.title}
+                />
             </AniLink>
 
             <Flex justifyContent="space-between" alignItems="center">

--- a/src/components/layout/menu/index.jsx
+++ b/src/components/layout/menu/index.jsx
@@ -29,22 +29,24 @@ const Menu = () => {
     `);
 
     return (
-        <MaxWidthContainer>
-            <Hidden smUp={true}>
-                <MobileMenu
-                    internal={contentfulMenu.internalLinks}
-                    external={contentfulMenu.externalLinks}
-                    blog={contentfulMenu.blogLink}
-                />
-            </Hidden>
-            <Hidden smDown={true}>
-                <DesktopMenu
-                    internal={contentfulMenu.internalLinks}
-                    external={contentfulMenu.externalLinks}
-                    blog={contentfulMenu.blogLink}
-                />
-            </Hidden>
-        </MaxWidthContainer>
+        <header role="banner">
+            <MaxWidthContainer>
+                <Hidden smUp={true}>
+                    <MobileMenu
+                        internal={contentfulMenu.internalLinks}
+                        external={contentfulMenu.externalLinks}
+                        blog={contentfulMenu.blogLink}
+                    />
+                </Hidden>
+                <Hidden smDown={true}>
+                    <DesktopMenu
+                        internal={contentfulMenu.internalLinks}
+                        external={contentfulMenu.externalLinks}
+                        blog={contentfulMenu.blogLink}
+                    />
+                </Hidden>
+            </MaxWidthContainer>
+        </header>
     );
 };
 

--- a/src/components/layout/menu/mobile/index.jsx
+++ b/src/components/layout/menu/mobile/index.jsx
@@ -20,11 +20,13 @@ const MobileMenu = ({ internal, external, blog }) => {
         query {
             contentfulMenu {
                 mobileLogo {
+                    title
                     fixed(height: 32) {
                         ...GatsbyContentfulFixed
                     }
                 }
                 blogLogo {
+                    title
                     fixed(height: 16) {
                         ...GatsbyContentfulFixed
                     }
@@ -76,6 +78,7 @@ const MobileMenu = ({ internal, external, blog }) => {
                                 {"BLOG "}
                                 <InlineLogo
                                     fixed={contentfulMenu.blogLogo.fixed}
+                                    alt={contentfulMenu.blogLogo.title}
                                 />
                             </>
                         )}
@@ -84,7 +87,10 @@ const MobileMenu = ({ internal, external, blog }) => {
             </AnimatedMenu>
             <ToolbarGrid>
                 <Link to={"/"}>
-                    <Image fixed={contentfulMenu.mobileLogo.fixed} />
+                    <Image
+                        fixed={contentfulMenu.mobileLogo.fixed}
+                        alt={contentfulMenu.mobileLogo.title}
+                    />
                 </Link>
 
                 <div onClick={handleToggle}>

--- a/src/components/layout/menu/mobile/index.jsx
+++ b/src/components/layout/menu/mobile/index.jsx
@@ -42,7 +42,7 @@ const MobileMenu = ({ internal, external, blog }) => {
     };
 
     return (
-        <>
+        <nav role="navigation" aria-label="Main">
             <AnimatedMenu open={open}>
                 {internal.map((link, i) => (
                     <MenuItem background={"dark"} key={i}>
@@ -102,7 +102,7 @@ const MobileMenu = ({ internal, external, blog }) => {
                 </div>
             </ToolbarGrid>
             <Spacer />
-        </>
+        </nav>
     );
 };
 

--- a/src/components/page-metadata/index.jsx
+++ b/src/components/page-metadata/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Helmet } from "react-helmet";
 import { graphql, useStaticQuery } from "gatsby";
 
-const PageMetadata = ({ title, description, disableRobots }) => {
+const PageMetadata = ({ title, description, disableRobots, locale }) => {
     const data = useStaticQuery(graphql`
         {
             site {
@@ -11,6 +11,7 @@ const PageMetadata = ({ title, description, disableRobots }) => {
                     title
                     description
                     robots
+                    locale
                 }
             }
         }
@@ -21,10 +22,15 @@ const PageMetadata = ({ title, description, disableRobots }) => {
         title: title || defaults.title,
         description: description || defaults.description,
         robots: disableRobots ? "none" : defaults.robots,
+        locale: locale || defaults.locale
     };
 
     return (
-        <Helmet>
+        <Helmet
+            htmlAttributes={{
+                lang: seo.locale
+            }}
+        >
             <title>{seo.title}</title>
             <meta name="description" content={seo.description} />
             <meta name="robots" content={seo.robots} />
@@ -36,6 +42,7 @@ PageMetadata.propTypes = {
     title: PropTypes.string,
     description: PropTypes.string,
     disableRobots: PropTypes.bool,
+    locale: PropTypes.string
 };
 
 export default PageMetadata;

--- a/src/pages/about/index.jsx
+++ b/src/pages/about/index.jsx
@@ -13,6 +13,7 @@ const About = () => {
         query {
             contentfulAboutUsPage {
                 id
+                node_locale
                 metaDescr {
                     metaDescr
                 }
@@ -62,6 +63,7 @@ const About = () => {
             <PageMetadata
                 title={contentfulAboutUsPage.metaTitle.metaTitle}
                 description={contentfulAboutUsPage.metaDescr.metaDescr}
+                locale={contentfulAboutUsPage.node_locale}
             />
             <Header
                 left={

--- a/src/pages/bcorp/index.jsx
+++ b/src/pages/bcorp/index.jsx
@@ -16,6 +16,7 @@ const BCorp = () => {
     const { contentfulImpactPage } = useStaticQuery(graphql`
         query {
             contentfulImpactPage {
+                node_locale
                 metaDescr {
                     metaDescr
                 }
@@ -83,6 +84,7 @@ const BCorp = () => {
             <PageMetadata
                 title={contentfulImpactPage.metaTitle.metaTitle}
                 description={contentfulImpactPage.metaDescr.metaDescr}
+                locale={contentfulImpactPage.node_locale}
             />
             <Header
                 left={

--- a/src/pages/contacts/index.jsx
+++ b/src/pages/contacts/index.jsx
@@ -18,6 +18,7 @@ const Contacts = () => {
     const { contentfulContactsPage } = useStaticQuery(graphql`
         query {
             contentfulContactsPage {
+                node_locale
                 description
                 header
                 metaTitle {
@@ -52,6 +53,7 @@ const Contacts = () => {
             <PageMetadata
                 title={contentfulContactsPage.metaTitle.metaTitle}
                 description={contentfulContactsPage.metaDescr.metaDescr}
+                locale={contentfulContactsPage.node_locale}
             />
             <MaxWidthContainer>
                 <BackgroundStripe>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -25,6 +25,7 @@ const Homepage = () => {
     const { contentfulHomepage } = useStaticQuery(graphql`
         query {
             contentfulHomepage {
+                node_locale
                 pageName
                 rightImage {
                     title
@@ -98,7 +99,7 @@ const Homepage = () => {
     return (
         <Layout>
             <ThemeProvider theme={rebassTheme}>
-                <PageMetadata />
+                <PageMetadata locale={contentfulHomepage.node_locale} />
                 <Header
                     left={
                         contentfulHomepage.leftHeader.childMarkdownRemark

--- a/src/pages/work-with-us/index.jsx
+++ b/src/pages/work-with-us/index.jsx
@@ -93,6 +93,7 @@ const WorkWithUs = () => {
                 }
             }
             contentfulWorkWithUsPage {
+                node_locale
                 handbookButton
                 handbookLink
                 handbookTitle
@@ -139,6 +140,7 @@ const WorkWithUs = () => {
             <PageMetadata
                 title={contentfulWorkWithUsPage.metaTitle.metaTitle}
                 description={contentfulWorkWithUsPage.metaDescr.metaDescr}
+                locale={contentfulWorkWithUsPage.node_locale}
             />
             <Header
                 left={

--- a/src/templates/simple-page/index.jsx
+++ b/src/templates/simple-page/index.jsx
@@ -11,6 +11,7 @@ import PageTitle from "../../components/page-title";
 export const pageQuery = graphql`
     query($slug: String!) {
         contentfulSimplePage(slug: { eq: $slug }) {
+            node_locale
             pageName
             metaTitle
             metaDescription {
@@ -35,6 +36,7 @@ const SimplePage = ({ data: { contentfulSimplePage } }) => {
                     contentfulSimplePage.metaDescription.metaDescription
                 }
                 disableRobots={contentfulSimplePage.metaRobots}
+                locale={contentfulSimplePage.node_locale}
             />
             <PageTitle>{contentfulSimplePage.pageName}</PageTitle>
             <PageContent>
@@ -47,13 +49,14 @@ const SimplePage = ({ data: { contentfulSimplePage } }) => {
 SimplePage.propTypes = {
     data: PropTypes.shape({
         contentfulSimplePage: PropTypes.shape({
+            node_locale: PropTypes.string.isRequired,
             pageName: PropTypes.string.isRequired,
             metaTitle: PropTypes.string,
             metaRobots: PropTypes.bool,
             metaDescription: PropTypes.object,
-            content: PropTypes.object.isRequired,
-        }).isRequired,
-    }).isRequired,
+            content: PropTypes.object.isRequired
+        }).isRequired
+    }).isRequired
 };
 
 export default SimplePage;


### PR DESCRIPTION
Solve some a11y issues: 

- missing `lang` HTML attribute: support contentful `node_lang` attribute + fallback to default
- missing `alt` image attribute
- missing structural elements (eg. `header`, `footer`, `main`, `nav`)

**TBD**
Fix some contrast issue, addressed by a separate pull request.